### PR TITLE
Support Alpine Linux

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ fi
 
 
 case "$format" in 
-  "deb"|"raw"|"docker")
+  "deb"|"raw"|"docker"|"alpine")
     
     if [[ -n "$distro" && "$distro" != $DEFAULT ]]; then
         distro_path="/$distro"


### PR DESCRIPTION
## what
- Add alpine support 

## why 
- Hardcoded list of supported formats does not include alpine
- Format is supported per docs https://help.cloudsmith.io/docs/alpine-repository