### PR TITLE
Refactored entrypoint; added BATS tests

### DIFF
--- a/.github/workflows/push-alpine.yml
+++ b/.github/workflows/push-alpine.yml
@@ -16,5 +16,5 @@ jobs:
           owner: "cloudsmith"
           repo: "actions"
           distro: "alpine/v3.9"
-          republish: "true" # needed since version is not changing
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-alpine-example-1.0.0-r0.apk" #real file that will repeat versions

--- a/.github/workflows/push-dart.yml
+++ b/.github/workflows/push-dart.yml
@@ -15,5 +15,5 @@ jobs:
           format: "dart"
           owner: "cloudsmith"
           repo: "actions"
-          republish: "true" # needed since version is not changing
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-dart-example-1.0.0.tar.gz" #real file that will repeat versions

--- a/.github/workflows/push-debian.yml
+++ b/.github/workflows/push-debian.yml
@@ -17,5 +17,5 @@ jobs:
           repo: "actions"
           distro: "ubuntu"
           release: "xenial"
-          republish: "true" # needed since version is not changing
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-debian-example-1.0.0-amd64.deb" #real file that will repeat versions

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -15,6 +15,5 @@ jobs:
           format: "docker"
           owner: "cloudsmith"
           repo: "actions"
-          republish: "true" # needed since version is not changing
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-docker-example-1.0.0.tar.gz" #alpine image saved to file
-

--- a/.github/workflows/push-python.yml
+++ b/.github/workflows/push-python.yml
@@ -15,5 +15,5 @@ jobs:
           format: "python"
           owner: "cloudsmith"
           repo: "actions"
-          republish: "true" # needed since version is not changing
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-python-example-1.0.0.tar.gz" #real file that will repeat versions

--- a/.github/workflows/push-raw.yml
+++ b/.github/workflows/push-raw.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   push:
     runs-on: ubuntu-latest
-    name: Raw File Push Test
+    name: Raw File Push Demo
     steps:
       - uses: actions/checkout@v1
       - name: Push

--- a/.github/workflows/push-rpm.yml
+++ b/.github/workflows/push-rpm.yml
@@ -1,9 +1,9 @@
-name: Push RPM
+name: Push RedHat/RPM
 on: push
 jobs:
   push:
     runs-on: ubuntu-latest
-    name: RPM Push Demo
+    name: RedHat/RPM Push Demo
     steps:
       - uses: actions/checkout@v1
       - name: Push
@@ -17,5 +17,5 @@ jobs:
           repo: "actions"
           distro: "any-distro"
           release: "any-version"
-          republish: "true" # needed since version is not changing
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-rpm-example-1.0-1.x86_64.rpm" #real file that will repeat versions

--- a/.github/workflows/test-bats.yml
+++ b/.github/workflows/test-bats.yml
@@ -1,0 +1,14 @@
+name: Test using BATS
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Execute BATS
+        run: test/libs/bats/bin/bats test/entrypoint.bats

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 AutoModality
+Copyright (c) 2020 Cloudsmith Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,26 +9,29 @@ Interact with Cloudsmith repositories using the [cloudmsith cli](https://pypi.or
 This action uses the Cloudsmith CLI and intends to be as similar
 to its structure and terminology as possible.
 
-**Implemented**
+**Supported**
 
-- Push
+- Push:
   - [Alpine format](https://cloudsmith.com/alpine-repository/)
   - [Dart format](https://cloudsmith.com/dart-repository/)
   - [Debian format](https://cloudsmith.com/debian-repository/)
   - [Docker format](https://cloudsmith.com/docker-registry/)
   - [Python format](https://cloudsmith.com/python-repository/)
-  - [RPM format](https://cloudsmith.com/rpm-repository/)
+  - [RedHat/RPM format](https://cloudsmith.com/rpm-repository/)
   - [Raw format](https://cloudsmith.com/raw-repository/)
 
-**Not Implemented**
+**Not Supported, But May Work**
 
-- Other package formats may work but official support has not yet been added to the Action. Please feel free to contribute pull requests to include supported Cloudsmith package formats.
+- Push:
+  - Other package formats may work but official support has not yet been added to the Action.
+
+Please feel free to contribute pull requests to add additional support!
 
 ## Cloudsmith API Key
 
 The API key is required for the cloudsmith-cli to work.
 
-Obtain the API Key from [Cloudsmith user settings](https://cloudsmith.io/user/settings/api/). You should use a less priveleged and generic account for Continuous Integration.
+Obtain the API Key from [Cloudsmith user settings](https://cloudsmith.io/user/settings/api/). You should use a least-privilege account for Continuous Integration.
 
 Add a secret named `CLOUDSMITH_API_KEY` and a value of the API Key obtained from cloudsmith. Secrets are maintained in the settings of each repository.
 
@@ -36,9 +39,9 @@ Pass your secret to the Action as seen in the Example usage.
 
 ## Examples
 
-The following examples use static files located within `test/fixtures`. When republishing existing packages the `republish` flag must be set to `true`.
+The following examples use static files located within `test/fixtures`. When republishing existing packages the `republish` flag must be set to `true`, but is otherwise recommended to not use this since it overwrites (and causes longer publish times).
 
-To pin to a specific release of this Github Action, replace `use: cloudsmith-io/action@master` with the version you require e.g. `uses: cloudsmith-io/action@0.3.0`.
+To pin to a specific release of this Github Action, replace `use: cloudsmith-io/action@master` with the version you require e.g. `uses: cloudsmith-io/action@0.4.0`.
 
 ### Alpine Package Push
 
@@ -61,7 +64,7 @@ jobs:
           owner: "cloudsmith"
           repo: "actions"
           distro: "alpine/v3.9"
-          republish: "true"
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-alpine-example-1.0.0-r0.apk"
 ```
 
@@ -85,7 +88,7 @@ jobs:
           format: "dart"
           owner: "cloudsmith"
           repo: "actions"
-          republish: "true"
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-dart-example-1.0.0.tar.gz"
 ```
 
@@ -111,7 +114,7 @@ jobs:
           repo: "actions"
           distro: "ubuntu"
           release: "xenial"
-          republish: "true"
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-debian-example_1.0.0_amd64.deb"
 ```
 
@@ -139,7 +142,7 @@ jobs:
           format: "docker"
           owner: "cloudsmith"
           repo: "actions"
-          republish: "true"
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/alpine-docker-test.tar.gz"
 ```
 
@@ -163,19 +166,19 @@ jobs:
           format: "python"
           owner: "cloudsmith"
           repo: "actions"
-          republish: "true"
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-python-example-1.0.0.tar.gz"
 ```
 
-### RPM Package RPM
+### RedHat/RPM Package Push
 
 ```yaml
-name: Push RPM
+name: Push RedHat/RPM
 on: push
 jobs:
   push:
     runs-on: ubuntu-latest
-    name: RPM Push Demo
+    name: RedHat/RPM Push Demo
     steps:
       - uses: actions/checkout@v1
       - name: Push
@@ -189,7 +192,7 @@ jobs:
           repo: "actions"
           distro: "any-distro"
           version: "any-version"
-          republish: "true" # needed since version is not changing
+          republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-rpm-example-1.0-1.x86_64.rpm" #real file that will repeat versions
 ```
 
@@ -201,7 +204,7 @@ on: push
 jobs:
   push:
     runs-on: ubuntu-latest
-    name: Raw File Push Test
+    name: Raw File Push Demo
     steps:
       - uses: actions/checkout@v1
       - name: Push

--- a/action.yml
+++ b/action.yml
@@ -1,71 +1,103 @@
 # action.yml
-name: 'Cloudsmith'
-description: 'Interact with Cloudsmith repositories'
+name: "Cloudsmith"
+description: "Interact with Cloudsmith repositories"
 inputs:
-  api-key:  
-    description: 'The Cloudsmith API Key in the Github Secrets repository settings.'
-    required: true
-    default: none
-  command:  
-    description: 'The desired action with cloudsmith (push, list, etc)'
-    required: true
-    default: help
-  format:  
-    description: 'The package format (deb,npm,maven, etc)'
-    required: true
-    default: none
-  owner:  
-    description: 'The organization that owns the repository'
-    required: true
-    default: none
-  repo:  
-    description: 'The repository slug'
-    required: true
-    default: none
-  file:  
-    description: 'The package file to be pushed'
-    required: true
-    default: none
-  distro:  
-    description: 'Debian: The distribution (ubuntu)'
+  api-version:
+    description: "All: If provided, a specific version of the Cloudsmith API is installed/used."
     required: false
     default: none
-  release:  
-    description: 'Debian: The named version of the release (xenial)'
+  cli-version:
+    description: "All: If provided, a specific version of the Cloudsmith CLI is installed/used."
+    required: false
+    default: none
+  skip-install-cli:
+    description: "All: If true, the Cloudsmith CLI will not be installed."
+    required: false
+    default: "false"
+  api-key:
+    description: "All: The Cloudsmith API Key (can be provided via GitHub secrets), or set as the CLOUDSMITH_API_KEY environment variable."
+    required: falsee
+    default: none
+  command:
+    description: "All: The desired action with cloudsmith (push, list, etc)."
+    required: false
+    default: "push"
+  format:
+    description: "All: The format (deb, npm, maven, etc) for the package."
+    required: true
+    default: none
+  owner:
+    description: "All: The user/organization that owns the repository, where the package will be pushed to."
+    required: true
+    default: none
+  repo:
+    description: "All: The repository slug (textual identifier), where the package will be pushed to."
+    required: true
+    default: none
+  file:
+    description: "All: The primary file for the package (e.g. my-package.deb)."
+    required: true
+    default: none
+  republish:
+    description: "All: If true, the uploaded package will overwrite any others with the same attributes."
+    required: false
+    default: "false"
+  wait-interval:
+    description: "All: The time in seconds to between checking synchronization."
+    required: false
+    default: none
+  no-wait-for-sync:
+    description: "All: If true, don't wait for package synchronization to complete before exiting (faster uploads)."
+    required: false
+    default: "false"
+  extra:
+    description: "All: Extra arguments passed to the Cloudsmith CLI, in-verbatim."
+    required: false
+    default: none
+  distro:
+    description: "Alpine/Debian/RedHat: The distribution for the package (e.g. ubuntu)"
+    required: false
+    default: none
+  release:
+    description: "Alpine/Debian/RedHat: The named version of the release for the package (e.g. xenial)"
     required: false
     default: none
   name:
-    description: '--name TEXT: The name of this package.'
+    description: "Raw: The name for the package."
     required: false
     default: none
   summary:
-    description: '--summary TEXT: A one-liner synopsis of this package.'
+    description: "Raw: The one-liner synopsis for the package."
     required: false
     default: none
   description:
-    description: '--description TEXT: A textual description of this package.'
+    description: "Raw: The longer textual description for the package."
     required: false
     default: none
-  republish:
-    description: '--republish:  If true, the uploaded package will overwrite
-                                  any others with the same attributes.'
+  version:
+    description: "Raw: The version for the package."
     required: false
-    default: "false"
+    default: none
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
   args: # these map in order with entrypoint.sh
-    - ${{ inputs.api-key }}
-    - ${{ inputs.command }}
-    - ${{ inputs.format }}
-    - ${{ inputs.owner }}
-    - ${{ inputs.repo }}
-    - ${{ inputs.file }}
-    - ${{ inputs.distro }}
-    - ${{ inputs.release }}
-    - ${{ inputs.version }}
-    - ${{ inputs.name }}
-    - ${{ inputs.summary }}
-    - ${{ inputs.description }}
-    - ${{ inputs.republish }}
-  
+    - -a ${{ inputs.api-version }}
+    - -c ${{ inputs.cli-version }}
+    - -C ${{ inputs.skip-install-cli }}
+    - -k ${{ inputs.api-key }}
+    - -K ${{ inputs.command }}
+    - -f ${{ inputs.format }}
+    - -o ${{ inputs.owner }}
+    - -r ${{ inputs.repo }}
+    - -F ${{ inputs.file }}
+    - -P ${{ inputs.republish }}
+    - -w ${{ inputs.wait-interval }}
+    - -W ${{ inputs.no-wait-for-sync }}
+    - -d ${{ inputs.distro }}
+    - -R ${{ inputs.release }}
+    - -n ${{ inputs.name }}
+    - -s ${{ inputs.summary }}
+    - -S ${{ inputs.description }}
+    - -V ${{ inputs.version }}
+    - -- ${{ inputs.extra }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,96 +1,199 @@
 #!/bin/bash
+self=$(readlink -f $BASH_SOURCE)
 
-set -e #exit on error
+declare -A options
 
 DEFAULT="none" # a way to handle ordered empty arguments of bash
 
-api_key=${1}
-command=${2}
-format=${3}
-owner=${4}
-repo=${5}
-file=${6}
-distro=${7}
-release=${8}
-version=${9}
-name=${10}
-summary=${11}
-description=${12}
-republish=${13}
+function unset_api_key {
+  unset CLOUDSMITH_API_KEY
+}
 
-# requires a CLOUDSMITH_API_KEY env variable to push
-if [[ -z $api_key || $api_key == $DEFAULT ]]; then
-    echo "CLOUDSMITH_API_KEY is required"
-    exit 1
-fi
+trap "unset_api_key" EXIT
 
-if [[ -z $command || $command == $DEFAULT ]]; then
-    echo "command is required"
-    exit 1
-fi
-if [[ -z $format || $format == $DEFAULT ]]; then
-    echo "format is required"
-    exit 1
-fi
-if [[ -z $owner || $owner == $DEFAULT ]]; then
-    echo "owner is required"
-    exit 1
-fi
-if [[ -z $repo || $repo == $DEFAULT ]]; then
-    echo "repo is required"
-    exit 1
-fi
-if [[ -z "$file" || $file == $DEFAULT   ]]; then
-    echo "file is required."
-    exit 3
-fi
-
-if [[ "$command" != "push" ]]; then
-    echo "command $command not yet implemented."
-    exit 3
-fi
+function warn {
+  echo "Warning: $@" 1>&2
+}
 
 
+function die {
+  echo "Error: $@" 1>&2
+  exit 1
+}
 
-case "$format" in
-  "alpine"|"dart"|"deb"|"docker"|"python"|"rpm"|"raw")
-    
-    if [[ -n "$distro" && "$distro" != $DEFAULT ]]; then
-        distro_path="/$distro"
-        if [[ -n "$release" && $release != $DEFAULT ]]; then
-            distro_path="$distro_path/$release"
-        fi
+
+function setup_options {
+  echo "SETUP OPTIONS"
+  options["api_version"]=$DEFAULT
+  options["cli_version"]=$DEFAULT
+  options["api_key"]=$DEFAULT
+  options["command"]="push"
+  options["format"]=$DEFAULT
+  options["owner"]=$DEFAULT
+  options["repo"]=$DEFAULT
+  options["file"]=$DEFAULT
+  options["republish"]=$DEFAULT
+  options["wait_interval"]=$DEFAULT
+  options["no_wait_for_sync"]=$DEFAULT
+  options["distro"]=$DEFAULT
+  options["release"]=$DEFAULT
+  options["name"]=$DEFAULT
+  options["summary"]=$DEFAULT
+  options["description"]=$DEFAULT
+  options["version"]=$DEFAULT
+
+  local OPTIND OPT
+  while getopts ":a:c:C:k:K:f:o:r:F:P:w:W:d:R:n:s:S:V:" OPT; do
+    case $OPT in
+      a) options["api_version"]="$OPTARG" ;;
+      c) options["cli_version"]="$OPTARG" ;;
+      C) options["skip_install_cli"]="$OPTARG" ;;
+      k) options["api_key"]="$OPTARG" ;;
+      K) options["command"]="$OPTARG" ;;
+      f) options["format"]="$OPTARG" ;;
+      o) options["owner"]="$OPTARG" ;;
+      r) options["repo"]="$OPTARG" ;;
+      F) options["file"]="$OPTARG" ;;
+      P) options["republish"]="$OPTARG" ;;
+      w) options["wait_interval"]="$OPTARG" ;;
+      W) options["no_wait_for_sync"]="$OPTARG" ;;
+      d) options["distro"]="$OPTARG" ;;
+      R) options["release"]="$OPTARG" ;;
+      n) options["name"]="$OPTARG" ;;
+      s) options["summary"]="$OPTARG" ;;
+      S) options["description"]="$OPTARG" ;;
+      V) options["version"]="$OPTARG" ;;
+      :) die "Option -$OPTARG requires an argument." ;;
+      ?) die "Invalid option -$OPTARG." ;;
+    esac
+  done
+  shift "$((OPTIND-1))"
+  options["extra"]="$@"
+}
+
+
+function check_option_set {
+  # Check if a value is set and non-default
+  local value=$@
+  test -n "$value" && test "$value" != "$DEFAULT"
+  return $?
+}
+
+
+function check_option_true {
+  # Check if a value is set and is true
+  local value=$@
+  test "$value" == "true"
+  return $?
+}
+
+
+function check_required_options {
+  for option in $@
+  do
+    local value="${options[$option]}"
+    if [[ -z "$value" || "$value" == "$DEFAULT" ]]; then
+      die "$option is required, but not set (got: $value)!"
     fi
+  done
+}
 
-    # these optional args provided only if valid
-    # notice the spaces are built into the args
-    if [[ -n "$version" && "$version" != $DEFAULT ]]; then
-        version_arg=" --version=\"$version\""
-    fi
-    if [[ -n "$name" && "$name" != "$DEFAULT" ]]; then
-        name_arg=" --name=\"$name\""
-    fi
-    if [[ -n "$summary" && "$summary" != $DEFAULT ]]; then
-        summary_arg=" --summary=\"$summary\""
-    fi
-    if [[ -n "$description" && "$description" != $DEFAULT ]]; then
-        description_arg=" --description=\"$description\""
-    fi
-    if [[ "$republish" == "true" || $republish == true ]]; then
-        republish_arg=" --republish"
-    fi
-  ;;
-  *)
-    echo "format $format not yet officially supported within action."
-  ;;
-esac
 
-export CLOUDSMITH_API_KEY=$api_key
+function install_api_cli {
+  if [[ "${options["skip_install_cli"]}" == "true" ]]; then
+    warn "Skipping Cloudsmith API/CLI installation"
+  else
+    echo "Starting Cloudsmith API/CLI installation ..."
 
-pip install cloudsmith-cli
+    check_option_set "${options["cli_version"]}" && {
+      pip install cloudsmith-cli==${options["cli_version"]}
+    } || {
+      pip install cloudsmith-cli
+    }
 
-request="cloudsmith push $action $format $owner/$repo$distro_path$version_arg$name_arg$summary_arg$description_arg$republish_arg $file"
+    check_option_set "${options["api_version"]}" && {
+      pip install cloudsmith-api==${options["api_version"]}
+    }
+  fi
+}
 
-echo $request
 
-eval $request
+function execute_push {
+  check_required_options format owner repo file
+
+  local context="${options["owner"]}/${options["repo"]}"
+  local params=""
+
+  # Universal options
+  check_option_true "${options["republish"]}" && {
+    params+=" --republish"
+  }
+  check_option_set "${options["wait_interval"]}" && {
+    params+=" --wait-interval='${options["wait_interval"]}'"
+  }
+  check_option_true "${options["no_wait_for_sync"]}" && {
+    params+=" --no-wait-for-sync"
+  }
+
+  # Format specific options
+  case "${options["format"]}" in
+    "alpine"|"deb"|"rpm")
+      check_required_options distro release
+      context+="/${options["distro"]}/${options["release"]}"
+    ;;
+
+    "raw")
+      check_option_set "${options["name"]}" && {
+        params+=" --name='${options["name"]}'"
+      }
+      check_option_set "${options["summary"]}" && {
+        params+=" --summary='${options["summary"]}'"
+      }
+      check_option_set "${options["description"]}" && {
+        params+=" --description='${options["description"]}'"
+      }
+      check_option_set "${options["version"]}" && {
+        params+=" --version='${options["version"]}'"
+      }
+    ;;
+
+    "dart"|"docker"|"python")
+      # Supported, but no additional options/params
+    ;;
+
+    *)
+      warn "Format ${options["format"]} is not yet officially" \
+        "supported within action (but might still work)."
+    ;;
+  esac
+
+  check_option_set "${options["api_key"]}" && {
+    export CLOUDSMITH_API_KEY="${options["api_key"]}"
+  }
+
+  local request="cloudsmith push ${options["action"]} ${options["format"]} $context ${options["file"]} $params ${options["extra"]}"
+  echo $request
+  eval $request
+}
+
+
+function main {
+  setup_options $@
+  install_api_cli
+
+  case "${options["command"]}" in
+    "push")
+      execute_push
+    ;;
+
+    *)
+      die "Command ${options["command"]} is not supported!"
+    ;;
+  esac
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+  main $@
+fi

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+load 'libs/bats-support/load'
+load 'libs/bats-assert/load'
+
+profile_script="${BATS_TEST_DIRNAME}/../entrypoint.sh"
+
+function setup_mocks {
+    function cloudsmith() { echo "EXECUTE cloudsmith ${@}"; }
+    export -f cloudsmith
+
+    function pip() { echo "EXECUTE pip ${@}"; }
+    export -f pip
+}
+
+
+@test ".only push command is supported" {
+    setup_mocks
+    run $profile_script -K foo
+    assert_failure
+    assert_output -p "Command foo is not supported!"
+}
+
+@test ".format is a required argument" {
+    setup_mocks
+    run $profile_script
+    assert_failure
+    assert_output -p "format is required"
+}
+
+@test ".owner is a required argument" {
+    setup_mocks
+    run $profile_script -f raw
+    assert_failure
+    assert_output -p "owner is required"
+}
+
+@test ".repo is a required argument" {
+    setup_mocks
+    run $profile_script -f raw -o my-org
+    assert_failure
+    assert_output -p "repo is required"
+}
+
+@test ".file is a required argument" {
+    setup_mocks
+    run $profile_script -f raw -o my-org -r my-repo
+    assert_failure
+    assert_output -p "file is required"
+}
+
+@test ".distro is a required argument, for debian" {
+    setup_mocks
+    run $profile_script -f deb -o my-org -r my-repo -F package.deb
+    assert_failure
+    assert_output -p "distro is required"
+}
+
+@test ".release is a required argument, for debian" {
+    setup_mocks
+    run $profile_script -f deb -o my-org -r my-repo -F package.deb -d ubuntu
+    assert_failure
+    assert_output -p "release is required"
+}
+
+@test ".distro is a required argument, for redhat" {
+    setup_mocks
+    run $profile_script -f rpm -o my-org -r my-repo -F package.rpm
+    assert_failure
+    assert_output -p "distro is required"
+}
+
+@test ".release is a required argument, for redhat" {
+    setup_mocks
+    run $profile_script -f rpm -o my-org -r my-repo -F package.rpm -d el
+    assert_failure
+    assert_output -p "release is required"
+}
+
+@test ".distro is a required argument, for alpine" {
+    setup_mocks
+    run $profile_script -f alpine -o my-org -r my-repo -F package.apk
+    assert_failure
+    assert_output -p "distro is required"
+}
+
+@test ".release is a required argument, for alpine" {
+    setup_mocks
+    run $profile_script -f alpine -o my-org -r my-repo -F package.apk -d alpine
+    assert_failure
+    assert_output -p "release is required"
+}
+
+@test ".cli is installed" {
+    setup_mocks
+    run $profile_script -f raw -o my-org -r my-repo -F package.raw
+    assert_success
+    assert_output -p "EXECUTE pip install cloudsmith-cli"
+    refute_output -p "EXECUTE pip install cloudsmith-api"
+}
+
+@test ".cli is installed, with a specific version" {
+    setup_mocks
+    run $profile_script -f raw -o my-org -r my-repo -F package.raw -c 1.0
+    assert_success
+    assert_output -p "EXECUTE pip install cloudsmith-cli==1.0"
+    refute_output -p "EXECUTE pip install cloudsmith-api"
+}
+
+@test ".api is installed, with a specific version" {
+    setup_mocks
+    run $profile_script -f raw -o my-org -r my-repo -F package.raw -a 1.0
+    assert_success
+    assert_output -p "EXECUTE pip install cloudsmith-cli"
+    assert_output -p "EXECUTE pip install cloudsmith-api==1.0"
+}
+
+@test ".cli is skipped if specified" {
+    setup_mocks
+    run $profile_script -f raw -o my-org -r my-repo -F package.raw -C
+    assert_failure
+    refute_output -p "EXECUTE pip install cloudsmith-cli"
+}
+
+@test ".execute successful debian push" {
+    setup_mocks
+    run $profile_script -f deb -o my-org -r my-repo -F package.deb -d ubuntu -R xenial
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push deb my-org/my-repo/ubuntu/xenial package.deb"
+}
+
+@test ".execute successful redhat push" {
+    setup_mocks
+    run $profile_script -f rpm -o my-org -r my-repo -F package.rpm -d el -R 7
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push rpm my-org/my-repo/el/7 package.rpm"
+}
+
+@test ".execute successful alpine push" {
+    setup_mocks
+    run $profile_script -f alpine -o my-org -r my-repo -F package.apk -d alpine -R v3.8
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push alpine my-org/my-repo/alpine/v3.8 package.apk"
+}
+
+@test ".execute successful dart push" {
+    setup_mocks
+    run $profile_script -f dart -o my-org -r my-repo -F package.dart
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push dart my-org/my-repo package.dart"
+}
+
+@test ".execute successful docker push" {
+    setup_mocks
+    run $profile_script -f docker -o my-org -r my-repo -F package.docker
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push docker my-org/my-repo package.docker"
+}
+
+@test ".execute successful python push" {
+    setup_mocks
+    run $profile_script -f python -o my-org -r my-repo -F package.whl
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push python my-org/my-repo package.whl"
+}
+
+@test ".execute successful raw push" {
+    setup_mocks
+    run $profile_script -f raw -o my-org -r my-repo -F package.zip -n my-name -s my-summary -S my-desc -V 1.0
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push raw my-org/my-repo package.zip --name=my-name --summary=my-summary --description=my-desc --version=1.0"
+}
+
+@test ".execute successful other push, but reports unsupported" {
+    setup_mocks
+    run $profile_script -f other -o my-org -r my-repo -F package.unk
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push other my-org/my-repo package.unk"
+    assert_output -p "Format other is not yet officially supported"
+}
+
+@test ".execute successful push, with optional universal args" {
+    setup_mocks
+    run $profile_script -f deb -o my-org -r my-repo -F package.deb -d ubuntu \
+        -R xenial -P true -w 10.0 -W true -- --verbatim-argument
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push deb my-org/my-repo/ubuntu/xenial package.deb --republish --wait-interval=10.0 --no-wait-for-sync --verbatim-argument"
+}


### PR DESCRIPTION
# What Changed?

- Refactored `entrypoint.sh` to make it testable via BATS.
- Added initial tests via BATS.
- Added support for `api-version`, `cli-version`, `skip-install-cli`, `wait-interval`, `no-wait-for-sync` and `extra` arguments.

With the `extra` argument, it's now possible to pass in-verbatim arguments to the Cloudsmith CLI. To workaround the issue of having to support every argument every offered by the CLI.