### PR TITLE
Only run package push from master

### DIFF
--- a/.github/workflows/push-alpine.yml
+++ b/.github/workflows/push-alpine.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   push:

--- a/.github/workflows/push-dart.yml
+++ b/.github/workflows/push-dart.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   push:

--- a/.github/workflows/push-debian.yml
+++ b/.github/workflows/push-debian.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   push:

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   push:

--- a/.github/workflows/push-python.yml
+++ b/.github/workflows/push-python.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   push:

--- a/.github/workflows/push-raw.yml
+++ b/.github/workflows/push-raw.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   push:

--- a/.github/workflows/push-rpm.yml
+++ b/.github/workflows/push-rpm.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   push:


### PR DESCRIPTION
### What's Changed

Outside contributors to this repository are unable to run `push` for packages as they do not have the API_KEY necessary for pushing the package to a repository. This PR ensures pushes for packages to a Cloudsmith repository only happen from master.

unblocks merging #13 