### PR TITLE
Run E2E tests on a schedule

### DIFF
--- a/.github/workflows/push-alpine.yml
+++ b/.github/workflows/push-alpine.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   push:

--- a/.github/workflows/push-cargo.yml
+++ b/.github/workflows/push-cargo.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   push:

--- a/.github/workflows/push-composer.yml
+++ b/.github/workflows/push-composer.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   push:

--- a/.github/workflows/push-dart.yml
+++ b/.github/workflows/push-dart.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   push:

--- a/.github/workflows/push-debian.yml
+++ b/.github/workflows/push-debian.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   push:

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   push:

--- a/.github/workflows/push-helm.yml
+++ b/.github/workflows/push-helm.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   push:

--- a/.github/workflows/push-python.yml
+++ b/.github/workflows/push-python.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   push:

--- a/.github/workflows/push-raw.yml
+++ b/.github/workflows/push-raw.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 
 jobs:
   push:

--- a/.github/workflows/push-rpm.yml
+++ b/.github/workflows/push-rpm.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - master
-
+  schedule:
+    # run every 6 hours
+    - cron: '0 0,6,12,18 * * *'
 jobs:
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Over the weekend the action was broken by a change to a dependency,
  e2e tests would've allowed us to discover the issue sooner - let's try
  running them on a schedule

