### PR TITLE
Add support for setting tags after push

### DIFF
--- a/.github/workflows/push-raw.yml
+++ b/.github/workflows/push-raw.yml
@@ -31,3 +31,4 @@ jobs:
           description: "See https://github.com/cloudsmith-io/action"
           version: ${{ github.sha }}
           extra: "--sync-attempts 5"  # Testing extras
+          tags: version:latest,foo

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ jobs:
           summary: "Github Action test of raw pushes"
           description: "See https://github.com/cloudsmith-io/action"
           version: ${{ github.sha}}
+          tags: version:latest,foo
 ```
 
 ## Thanks

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,10 @@ inputs:
     description: "Raw: The version for the package."
     required: false
     default: none
+  tags:
+    description: "All: The tags to add to the package."
+    required: false
+    default: ""
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -104,4 +108,5 @@ runs:
     - -s${{ inputs.summary }}
     - -S${{ inputs.description }}
     - -V${{ inputs.version }}
+    - -t${{ inputs.tags }}
     - " -- ${{ inputs.extra }}"

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -177,6 +177,14 @@ function setup_mocks {
     assert_output -p "EXECUTE cloudsmith push raw my-org/my-repo package.zip --name=my-name --summary=Some Summary --description=Some Description --version=1.0"
 }
 
+@test ".execute successful raw push with tags set" {
+    setup_mocks
+    run $profile_script -f raw -o my-org -r my-repo -F package.zip -n my-name -s "Some Summary" -S "Some Description" -V 1.0 -t version:latest,foo
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push raw my-org/my-repo package.zip --name=my-name --summary=Some Summary --description=Some Description --version=1.0"
+    assert_output -e "EXECUTE cloudsmith tags add my-org/my-repo/[^/]+ version:latest,foo"
+}
+
 @test ".execute successful cargo push" {
     setup_mocks
     run $profile_script -f cargo -o my-org -r my-repo -F package.crate


### PR DESCRIPTION
Passing `--tags` in extra argument does not work for `version:latest` for some reason so we need to do that in a separate step.

Fixes: https://github.com/cloudsmith-io/action/issues/16
