### PR TITLE
Revert "Add support for setting tags after push (#27)"

### DIFF
--- a/.github/workflows/push-raw.yml
+++ b/.github/workflows/push-raw.yml
@@ -31,4 +31,3 @@ jobs:
           description: "See https://github.com/cloudsmith-io/action"
           version: ${{ github.sha }}
           extra: "--sync-attempts 5"  # Testing extras
-          tags: version:latest,foo

--- a/README.md
+++ b/README.md
@@ -294,7 +294,6 @@ jobs:
           summary: "Github Action test of raw pushes"
           description: "See https://github.com/cloudsmith-io/action"
           version: ${{ github.sha}}
-          tags: version:latest,foo
 ```
 
 ## Thanks

--- a/action.yml
+++ b/action.yml
@@ -82,10 +82,6 @@ inputs:
     description: "Raw: The version for the package."
     required: false
     default: none
-  tags:
-    description: "All: The tags to add to the package."
-    required: false
-    default: ""
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -108,5 +104,4 @@ runs:
     - -s${{ inputs.summary }}
     - -S${{ inputs.description }}
     - -V${{ inputs.version }}
-    - -t${{ inputs.tags }}
     - " -- ${{ inputs.extra }}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,14 +40,12 @@ function setup_options {
   options["summary"]=$DEFAULT
   options["description"]=$DEFAULT
   options["version"]=$DEFAULT
-  # Comma-separated list
-  options["tags"]=""
   options["extra"]=$DEFAULT
 
   local raw_opts="$@"
   local OPTIND OPT
 
-  while getopts ":a:c:C:k:K:f:o:r:F:P:w:W:d:R:n:s:S:V:t:" OPT; do
+  while getopts ":a:c:C:k:K:f:o:r:F:P:w:W:d:R:n:s:S:V:" OPT; do
     case $OPT in
       a) options["api_version"]="$OPTARG" ;;
       c) options["cli_version"]="$OPTARG" ;;
@@ -67,7 +65,6 @@ function setup_options {
       s) options["summary"]="$OPTARG" ;;
       S) options["description"]="$OPTARG" ;;
       V) options["version"]="$OPTARG" ;;
-      t) options["tags"]="$OPTARG" ;;
       :) die "Option -$OPTARG requires an argument." ;;
       ?)
         if [[ "$OPTARG" == *"-"* ]]; then
@@ -193,23 +190,6 @@ function execute_push {
   local request="cloudsmith push ${options["action"]} ${options["format"]} $context ${options["file"]} $params $extra"
   echo $request
   eval $request
-
-  test -n "${options["tags"]}" && {
-    query="filename:${options["file"]}"
-    check_option_set "${options["version"]}" && {
-      query+=" version:${options["version"]}"
-    }
-
-    slug=$(python3 -c "import json, subprocess, sys
-context = sys.argv[1]
-query = sys.argv[2]
-response = subprocess.check_output(['cloudsmith', 'list', 'packages', context, '--output-format', 'pretty_json', '--query', query])
-data = json.loads(response)['data']
-assert len(data) == 1, f'Query “{query}” needs to match a single package in repository “{context}” to be able to add tags.'
-print(data[0]['slug_perm'])
-" "$context" "$query")
-    cloudsmith tags add "${context}/${slug}" "${options["tags"]}"
-  }
 }
 
 

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -177,14 +177,6 @@ function setup_mocks {
     assert_output -p "EXECUTE cloudsmith push raw my-org/my-repo package.zip --name=my-name --summary=Some Summary --description=Some Description --version=1.0"
 }
 
-@test ".execute successful raw push with tags set" {
-    setup_mocks
-    run $profile_script -f raw -o my-org -r my-repo -F package.zip -n my-name -s "Some Summary" -S "Some Description" -V 1.0 -t version:latest,foo
-    assert_success
-    assert_output -p "EXECUTE cloudsmith push raw my-org/my-repo package.zip --name=my-name --summary=Some Summary --description=Some Description --version=1.0"
-    assert_output -e "EXECUTE cloudsmith tags add my-org/my-repo/[^/]+ version:latest,foo"
-}
-
 @test ".execute successful cargo push" {
     setup_mocks
     run $profile_script -f cargo -o my-org -r my-repo -F package.crate


### PR DESCRIPTION
Reverts #27 

Doesn't seem to be backwards compatible with pushes that don't include tags

`Getting list of packages ... OK
Traceback (most recent call last):
  File "<string>", line 6, in <module>
AssertionError: Query “filename:test/fixture/raw_file.txt version:4900c03962d6a8d37b700a20718c1dee87fba48e” needs to match a single package in repository “cloudsmith/actions” to be able to add tags.
Usage: cloudsmith tags add [OPTIONS] OWNER/REPO/PACKAGE TAGS
Try 'cloudsmith tags add -h' for help.
Error: Invalid value for 'OWNER/REPO/PACKAGE': Individual values cannot be blank`
