### PR TITLE
Add support for setting tags after push

### DIFF
--- a/.github/workflows/push-raw.yml
+++ b/.github/workflows/push-raw.yml
@@ -31,3 +31,4 @@ jobs:
           description: "See https://github.com/cloudsmith-io/action"
           version: ${{ github.sha }}
           extra: "--sync-attempts 5"  # Testing extras
+          tags: version:latest,foo

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ jobs:
           summary: "Github Action test of raw pushes"
           description: "See https://github.com/cloudsmith-io/action"
           version: ${{ github.sha}}
+          tags: version:latest,foo
 ```
 
 ## Thanks

--- a/action.yml
+++ b/action.yml
@@ -82,6 +82,10 @@ inputs:
     description: "Raw: The version for the package."
     required: false
     default: none
+  tags:
+    description: "All: The tags to add to the package."
+    required: false
+    default: ""
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -104,4 +108,5 @@ runs:
     - -s${{ inputs.summary }}
     - -S${{ inputs.description }}
     - -V${{ inputs.version }}
+    - -t${{ inputs.tags }}
     - " -- ${{ inputs.extra }}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,12 +40,14 @@ function setup_options {
   options["summary"]=$DEFAULT
   options["description"]=$DEFAULT
   options["version"]=$DEFAULT
+  # Comma-separated list
+  options["tags"]=""
   options["extra"]=$DEFAULT
 
   local raw_opts="$@"
   local OPTIND OPT
 
-  while getopts ":a:c:C:k:K:f:o:r:F:P:w:W:d:R:n:s:S:V:" OPT; do
+  while getopts ":a:c:C:k:K:f:o:r:F:P:w:W:d:R:n:s:S:V:t:" OPT; do
     case $OPT in
       a) options["api_version"]="$OPTARG" ;;
       c) options["cli_version"]="$OPTARG" ;;
@@ -65,6 +67,7 @@ function setup_options {
       s) options["summary"]="$OPTARG" ;;
       S) options["description"]="$OPTARG" ;;
       V) options["version"]="$OPTARG" ;;
+      t) options["tags"]="$OPTARG" ;;
       :) die "Option -$OPTARG requires an argument." ;;
       ?)
         if [[ "$OPTARG" == *"-"* ]]; then
@@ -190,6 +193,21 @@ function execute_push {
   local request="cloudsmith push ${options["action"]} ${options["format"]} $context ${options["file"]} $params $extra"
   echo $request
   eval $request
+
+  if [[ -n "${options["tags"]}" ]]; then
+    query="filename:${options["file"]}"
+    check_option_set "${options["version"]}" && {
+      query+=" version:${options["version"]}"
+    }
+
+    slug=$(cloudsmith list packages "$context" --output-format pretty_json --query "$query" | python3 -c "import json, sys
+response = sys.stdin.read()
+data = json.loads(response)['data']
+assert len(data) == 1, f'Query “{query}” needs to match a single package in repository “{context}” to be able to add tags.'
+print(data[0]['slug_perm'])
+")
+    cloudsmith tags add "${context}/${slug}" "${options["tags"]}"
+  fi
 }
 
 

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -5,7 +5,13 @@ load 'libs/bats-assert/load'
 profile_script="${BATS_TEST_DIRNAME}/../entrypoint.sh"
 
 function setup_mocks {
-    function cloudsmith() { echo "EXECUTE cloudsmith ${@}"; }
+    function cloudsmith() {
+        if [[ "$1" = "list" ]] && [[ "$2" = "packages" ]]; then
+            echo '{"data": [{"slug_perm": "ovvoZfToHWCc"}]}'
+        else
+            echo "EXECUTE cloudsmith ${@}";
+        fi
+    }
     export -f cloudsmith
 
     function pip() { echo "EXECUTE pip ${@}"; }
@@ -175,6 +181,14 @@ function setup_mocks {
     run $profile_script -f raw -o my-org -r my-repo -F package.zip -n my-name -s "Some Summary" -S "Some Description" -V 1.0
     assert_success
     assert_output -p "EXECUTE cloudsmith push raw my-org/my-repo package.zip --name=my-name --summary=Some Summary --description=Some Description --version=1.0"
+}
+
+@test ".execute successful raw push with tags set" {
+    setup_mocks
+    run $profile_script -f raw -o my-org -r my-repo -F package.zip -n my-name -s "Some Summary" -S "Some Description" -V 1.0 -t version:latest,foo
+    assert_success
+    assert_output -p "EXECUTE cloudsmith push raw my-org/my-repo package.zip --name=my-name --summary=Some Summary --description=Some Description --version=1.0"
+    assert_output -p "EXECUTE cloudsmith tags add my-org/my-repo/ovvoZfToHWCc version:latest,foo"
 }
 
 @test ".execute successful cargo push" {


### PR DESCRIPTION
### What's Changed

Passing `--tags` in extra argument does not work for `version:latest` for some reason so we need to do that in a separate step.

Fixes: #16
