### PR TITLE
Pass through variables to the python script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -203,7 +203,7 @@ function execute_push {
     slug=$(cloudsmith list packages "$context" --output-format pretty_json --query "$query" | python3 -c "import json, sys
 response = sys.stdin.read()
 data = json.loads(response)['data']
-assert len(data) == 1, f'Query “{query}” needs to match a single package in repository “{context}” to be able to add tags.'
+assert len(data) == 1, f'Query “$query” needs to match a single package in repository “$context” to be able to add tags.'
 print(data[0]['slug_perm'])
 ")
     cloudsmith tags add "${context}/${slug}" "${options["tags"]}"


### PR DESCRIPTION
### What's Changed

Fix CI failure:

```
Traceback (most recent call last):
  File "<string>", line 4, in <module>
NameError: name 'query' is not defined
Usage: cloudsmith tags add [OPTIONS] OWNER/REPO/PACKAGE TAGS
Try 'cloudsmith tags add -h' for help.

Error: Invalid value for 'OWNER/REPO/PACKAGE': Individual values cannot be blank
```
from https://github.com/cloudsmith-io/action/runs/8268312418?check_suite_focus=true#step:3:144

cc @jtojnar