### PR TITLE
Another attempt at fixing file with tags on CI

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -195,7 +195,7 @@ function execute_push {
   eval $request
 
   if [[ -n "${options["tags"]}" ]]; then
-    query="filename:${options["file"]}"
+    query="filename:$(basename "${options["file"]}")"
     check_option_set "${options["version"]}" && {
       query+=" version:${options["version"]}"
     }


### PR DESCRIPTION
The hypothesis is that when we pass a path to `cloudsmith push`, it will only use the file name to store it on the server so we need to use the same to identify it in the query.
