### PR TITLE
fix: use Cloudsmith hosted docker image for running the action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM python:3.8-slim
+FROM docker.cloudsmith.io/cloudsmith/actions-images/python:3.8-slim
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
### What's Changed

Use a Cloudsmith hosted Docker image to run the Github Action. This helps avoid Docker Hub rate limits for users with self-hosted runners.
