### PR TITLE
Github Actions Maven make more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ jobs:
     name: Maven Push Demo
     steps:
       - uses: actions/checkout@v2
+
       - name: Push
         id: push
         uses: ./
@@ -268,9 +269,9 @@ jobs:
           format: "maven"
           owner: "cloudsmith"
           repo: "actions"
-          pom-file: "test/fixture/cloudsmith-maven-example-1.0-SNAPSHOT.pom"
+          pom-file: "pom.xml"
           republish: "true" # needed ONLY if version is not changing
-          file: "test/fixture/cloudsmith-maven-example-1.0-SNAPSHOT.jar" #real file that will repeat versions
+          file: "target/yourproject-0.0.1-SNAPSHOT.jar" #real file that will repeat versions
 ```
 
 ### NPM Package Push


### PR DESCRIPTION
As a returning Java developer I wasn't quite sure where the idiomatic build location was, whether under ~/.m2 or elsewhere, I was also a bit confused by the reference to the pom file, wasn't sure if mvn would be doing some post-processing on it. In any event this seems a more straightforward example to me.

### What's Changed

> A description of the issue/feature; reference the issue number (if one exists).
