### PR TITLE
ENG-2978: Temp remove symbols support

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ jobs:
           repo: "actions"
           republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-nuget-example.1.0.0.nupkg" #real file that will repeat versions
-          symbols-file: "test/fixture/cloudsmith-nuget-example.1.0.0.snupkg"
+          # symbols-file: "test/fixture/cloudsmith-nuget-example.1.0.0.snupkg" (Temporarily disbaled)
 ```
 
 ### Python Package Push

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,7 @@ runs:
     - -d${{ inputs.distro }}
     - -R${{ inputs.release }}
     - -n${{ inputs.name }}
-    - -N${{ inputs.symbols-file }}
+    # - -N${{ inputs.symbols-file }} awaiting ENG-1456
     - -s${{ inputs.summary }}
     - -S${{ inputs.description }}
     - -V${{ inputs.version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ function setup_options {
   options["description"]=$DEFAULT
   options["version"]=$DEFAULT
   options["pom_file"]=$DEFAULT
-  options["symbols_file"]=$DEFAULT
+  # options["symbols_file"]=$DEFAULT - Awaiting ENG-1456
   options["extra"]=$DEFAULT
 
   local raw_opts="$@"
@@ -64,7 +64,7 @@ function setup_options {
       d) options["distro"]="$OPTARG" ;;
       R) options["release"]="$OPTARG" ;;
       n) options["name"]="$OPTARG" ;;
-      N) options["symbols_file"]="$OPTARG" ;;
+      # N) options["symbols_file"]="$OPTARG" ;; awaiting ENG-1456
       s) options["summary"]="$OPTARG" ;;
       S) options["description"]="$OPTARG" ;;
       V) options["version"]="$OPTARG" ;;
@@ -172,18 +172,19 @@ function execute_push {
       }
     ;;
 
-    "nuget")
-      check_option_set "${options["symbols_file"]}" && {
-        params+=" --symbols-file='${options["symbols_file"]}'"
-      }
-    ;;
+    # Nuget symbols - awaiting fix ENG-1456
+    # "nuget")
+    #   check_option_set "${options["symbols_file"]}" && {
+    #     params+=" --symbols-file='${options["symbols_file"]}'"
+    #   }
+    # ;;
 
     "maven")
       check_required_options pom_file
       params+=" --pom-file='${options["pom_file"]}'"
     ;;
 
-    "cargo"|"dart"|"docker"|"helm"|"python"|"composer"|"cocoapods"|"npm"|"go")
+    "cargo"|"dart"|"docker"|"helm"|"python"|"composer"|"cocoapods"|"npm"|"nuget"|"go")
       # Supported, but no additional options/params
     ;;
 

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -200,9 +200,9 @@ function setup_mocks {
 
 @test ".execute successful nuget push" {
     setup_mocks
-    run $profile_script -f nuget -o my-org -r my-repo -F package.nupkg -N package.snupkg
+    run $profile_script -f nuget -o my-org -r my-repo -F package.nupkg
     assert_success
-    assert_output -p "EXECUTE cloudsmith push nuget my-org/my-repo package.nupkg --symbols-file=package.snupkg"
+    assert_output -p "EXECUTE cloudsmith push nuget my-org/my-repo package.nupkg"
 }
 
 @test ".execute successful go push" {


### PR DESCRIPTION
WHY?

Customers are currently seeing errors related to symbols package being uploaded - this is being caused by us not fulling supporting symbols upload via the CLI and it's awaiting fix. Once fixed, we can re-release the symbols support.