### PR TITLE
chore: update run path for entrypoint.sh

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,7 @@ runs:
     - name: Run Entrypoint
       shell: bash
       run: |
-        bash entrypoint.sh \
+        bash ${{ github.action_path }}/entrypoint.sh \
         -D${{ inputs.description }} \
         -k${{ inputs.api-key }} \
         -K${{ inputs.command }} \


### PR DESCRIPTION
### What's Changed

* Use the `github.action_path` when attempting to invoke the entrypoint.sh
