### PR TITLE
chore: fix up symbol support

### DIFF
--- a/.github/workflows/push-nuget.yml
+++ b/.github/workflows/push-nuget.yml
@@ -27,4 +27,4 @@ jobs:
           repo: "actions"
           republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-nuget-example.1.0.0.nupkg" #real file that will repeat versions
-          # symbols-file: 
+          symbols-file: "test/fixture/cloudsmith-nuget-example.1.0.0.snupkg"

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ jobs:
           repo: "actions"
           republish: "true" # needed ONLY if version is not changing
           file: "test/fixture/cloudsmith-nuget-example.1.0.0.nupkg" #real file that will repeat versions
-          # symbols-file: "test/fixture/cloudsmith-nuget-example.1.0.0.snupkg" (Temporarily disbaled)
+          symbols-file: "test/fixture/cloudsmith-nuget-example.1.0.0.snupkg"
 ```
 
 ### Python Package Push

--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,10 @@ inputs:
     description: "Maven: Relevant POM file for the maven package."
     required: false
     default: none
+  symbols-file:
+    description: "Nuget: Relevant Symbols file for the nuget package."
+    required: false
+    default: none
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
### What's Changed

> A description of the issue/feature; reference the issue number (if one exists).

With recent code changes and added support for nuget symbols via CLI - the current code was missing a reference breaking normal nuget uploads. This fixes and adds nuget symbol support to GHA.