### PR TITLE
chore(Remove need for JQ)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -131,9 +131,18 @@ runs:
       shell: bash
       env:
         USE_EXECUTABLE: ${{ inputs.use-executable }}
-        GITHUB_ACTION_PATH: ${{ github.action_path }}
       run: |
-        bash ${{ github.action_path }}/entrypoint.sh \
+        if [ -f "${{ github.action_path }}/entrypoint.sh" ]; then
+          ENTRYPOINT_PATH="${{ github.action_path }}/entrypoint.sh"
+          echo "Using entrypoint.sh from ${{ github.action_path }}"
+        elif [ -f "${GITHUB_ACTION_PATH}/entrypoint.sh" ]; then
+          ENTRYPOINT_PATH="${GITHUB_ACTION_PATH}/entrypoint.sh"
+          echo "Using entrypoint.sh from ${GITHUB_ACTION_PATH}"
+        else
+          echo "entrypoint.sh not found in either ${{ github.action_path }} or ${GITHUB_ACTION_PATH}"
+          exit 1
+        fi
+        bash $ENTRYPOINT_PATH \
         -k ${{ inputs.api-key }} \
         -K ${{ inputs.command }} \
         -f ${{ inputs.format }} \

--- a/action.yml
+++ b/action.yml
@@ -105,14 +105,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install jq
-      if: inputs.use-executable == 'true'
-      uses: dcarbone/install-jq-action@v2.1.0
     - name: Download latest cloudsmith-cli executable
       if: inputs.use-executable == 'true'
       shell: bash
       run: |
-        download_url=$(curl --silent "https://api.github.com/repos/cloudsmith-io/cloudsmith-cli/releases/latest" | jq -r '.assets[0].browser_download_url')
+        if command -v sed &> /dev/null; then
+          download_url=$(curl --silent "https://api.github.com/repos/cloudsmith-io/cloudsmith-cli/releases/latest" | sed -n 's/.*"browser_download_url": "\([^"]*\)".*/\1/p' | head -1)
+        else
+          download_url=$(curl --silent "https://api.github.com/repos/cloudsmith-io/cloudsmith-cli/releases/latest" | awk '/"browser_download_url":/ {print $2}' | tr -d '"' | head -1)
+        fi
         sudo wget -O /usr/local/bin/cloudsmith $download_url
         sudo chmod +x /usr/local/bin/cloudsmith
     - name: Setup Python


### PR DESCRIPTION
### What's Changed

Remove the need for JQ to be installed and use `sed` or `awk` instead to grab the latest release of the CLI. Some customers can't use 3rd party actions that are not verified, this PR should tackle this.
