### PR TITLE
CENG-269: Add macos runner support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,6 +109,12 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+    # Upgrade Bash on macOS - this is required as the default version of Bash on macOS runner is 3.9
+    - name: Upgrade Bash on macOS 
+      if: runner.os == 'macOS'
+      run: |
+        brew install bash
+      shell: bash
     - name: Download latest cloudsmith-cli executable
       if: inputs.use-executable == 'true'
       shell: bash


### PR DESCRIPTION
### What's Changed

* Add support for macOS runner by updating the version of bash that comes pre-installed (v3.2) on default GHA runners.